### PR TITLE
Printing to ByteBuffer (bytes)

### DIFF
--- a/benchmark/src/main/scala/io/circe/jackson/benchmark/Benchmark.scala
+++ b/benchmark/src/main/scala/io/circe/jackson/benchmark/Benchmark.scala
@@ -4,6 +4,7 @@ import cats.Eq
 import io.circe.{ Decoder, Encoder, Json => JsonC }
 import io.circe.generic.semiauto._
 import io.circe.jawn._
+import java.nio.ByteBuffer
 import java.util.concurrent.TimeUnit
 import org.openjdk.jmh.annotations._
 
@@ -70,11 +71,17 @@ class PrintingBenchmark extends ExampleData {
   def printIntsC: String = intsC.noSpaces
 
   @Benchmark
-  def printIntsCJ: String = io.circe.jackson.jacksonPrint(intsC)
+  def printIntsCJString: String = io.circe.jackson.jacksonPrint(intsC)
+
+  @Benchmark
+  def printIntsCJBytes: ByteBuffer = io.circe.jackson.jacksonPrintByteBuffer(intsC)
 
   @Benchmark
   def printFoosC: String = foosC.noSpaces
 
   @Benchmark
-  def printFoosCJ: String = io.circe.jackson.jacksonPrint(foosC)
+  def printFoosCJString: String = io.circe.jackson.jacksonPrint(foosC)
+
+  @Benchmark
+  def printFoosCJBytes: ByteBuffer = io.circe.jackson.jacksonPrintByteBuffer(foosC)
 }

--- a/benchmark/src/test/scala/io/circe/jackson/benchmark/PrintingBenchmarkSpec.scala
+++ b/benchmark/src/test/scala/io/circe/jackson/benchmark/PrintingBenchmarkSpec.scala
@@ -2,11 +2,18 @@ package io.circe.jackson.benchmark
 
 import io.circe.parser.decode
 import org.scalatest.FlatSpec
+import java.nio.ByteBuffer
 
 class PrintingBenchmarkSpec extends FlatSpec {
   val benchmark: PrintingBenchmark = new PrintingBenchmark
 
   import benchmark._
+
+  private[this] def byteBufferToString(bb: ByteBuffer): String = {
+    val array = new Array[Byte](bb.remaining)
+    bb.get(array)
+    new String(array, "UTF-8")
+  }
 
   private[this] def decodeInts(json: String): Option[List[Int]] =
     decode[List[Int]](json).fold(_ => None, Some(_))
@@ -15,10 +22,12 @@ class PrintingBenchmarkSpec extends FlatSpec {
     decode[Map[String, Foo]](json).fold(_ => None, Some(_))
 
   it should "correctly print integers using Circe with Jackson" in {
-    assert(decodeInts(printIntsCJ) === Some(ints))
+    assert(decodeInts(printIntsCJString) === Some(ints))
+    assert(decodeInts(byteBufferToString(printIntsCJBytes)) === Some(ints))
   }
 
   it should "correctly print case classes using Circe with Jackson" in {
-    assert(decodeFoos(printFoosCJ) === Some(foos))
+    assert(decodeFoos(printFoosCJString) === Some(foos))
+    assert(decodeFoos(byteBufferToString(printFoosCJBytes)) === Some(foos))
   }
 }

--- a/shared/src/main/scala/io/circe/jackson/WithJacksonMapper.scala
+++ b/shared/src/main/scala/io/circe/jackson/WithJacksonMapper.scala
@@ -2,7 +2,7 @@ package io.circe.jackson
 
 import com.fasterxml.jackson.core.{ JsonFactory, JsonParser }
 import com.fasterxml.jackson.databind.ObjectMapper
-import java.io.{ File, StringWriter }
+import java.io.{ File, Writer }
 
 class WithJacksonMapper {
   protected final val mapper: ObjectMapper = (new ObjectMapper).registerModule(CirceJsonModule)
@@ -12,5 +12,5 @@ class WithJacksonMapper {
   protected final def jsonFileParser(file: File): JsonParser = jsonFactory.createParser(file)
   protected final def jsonBytesParser(bytes: Array[Byte]): JsonParser =
     jsonFactory.createParser(bytes)
-  protected final def stringJsonGenerator(out: StringWriter) = jsonFactory.createGenerator(out)
+  protected final def jsonGenerator(out: Writer) = jsonFactory.createGenerator(out)
 }

--- a/shared/src/test/scala/io/circe/jackson/JacksonInstances.scala
+++ b/shared/src/test/scala/io/circe/jackson/JacksonInstances.scala
@@ -18,6 +18,7 @@ import io.circe.testing.ArbitraryInstances
 import org.scalacheck.Arbitrary
 import scala.util.matching.Regex
 import scala.util.Try
+import java.nio.ByteBuffer
 
 trait JacksonInstances { this: ArbitraryInstances =>
   /**
@@ -31,6 +32,8 @@ trait JacksonInstances { this: ArbitraryInstances =>
     case (JNumber(a), JString(b)) => a.toString == b
     case (a, b) => Json.eqJson.eqv(a, b)
   }
+
+  implicit val eqByteBuffer: Eq[ByteBuffer] = Eq.fromUniversalEquals
 
   private[this] val SigExpPattern: Regex = """[^eE]+[eE][+-]?(\d+)""".r
   private[this] val replacement: JsonNumber = JsonBiggerDecimal(BiggerDecimal.fromLong(0L))

--- a/shared/src/test/scala/io/circe/jackson/JacksonPrintingSuite.scala
+++ b/shared/src/test/scala/io/circe/jackson/JacksonPrintingSuite.scala
@@ -1,9 +1,14 @@
 package io.circe.jackson
 
 import io.circe.Json
+import java.nio.ByteBuffer
 
 class JacksonPrintingSuite extends CirceSuite with JacksonInstances {
   "jacksonPrint" should "produce round-trippable output" in forAll(arbitraryCleanedJson.arbitrary) { (json: Json) =>
     assert(io.circe.jawn.parse(jacksonPrint(json)) === Right(json))
+  }
+
+  "jacksonPrintByteBuffer" should "produce the same output as jacksonPrint" in forAll(arbitraryCleanedJson.arbitrary) { (json: Json) =>
+    assert(jacksonPrintByteBuffer(json) === ByteBuffer.wrap(jacksonPrint(json).getBytes("UTF-8")))
   }
 }


### PR DESCRIPTION
As discussed in https://github.com/circe/circe/issues/536 and https://github.com/finagle/finch/issues/676 this PR introduces `jacksonPrintBytes` that prints directly into `ByteBuffer`.

I run some benchmarks and the results are quite surprising. The throughput is never better when printing to bytes, but the allocation rate is significantly lower (2x for case classes). Not sure I can reasonably explain neither why allocations are nearly the same when printing int arrays nor why throughput isn't improved. Although, I think it's a reasonable first step in binary printing.

```
[info] Benchmark                                                              Mode  Cnt       Score       Error   Units
[info] PrintingBenchmark.printFoosC                                          thrpt   20    2894.216 ±   120.682   ops/s
[info] PrintingBenchmark.printFoosC:·gc.alloc.rate.norm                      thrpt   20  454564.587 ±  1799.636    B/op

[info] PrintingBenchmark.printFoosCJBytes                                    thrpt   20    3418.018 ±    50.857   ops/s
[info] PrintingBenchmark.printFoosCJBytes:·gc.alloc.rate.norm                thrpt   20  259067.149 ±    71.022    B/op

[info] PrintingBenchmark.printFoosCJString                                   thrpt   20    3547.072 ±    55.888   ops/s
[info] PrintingBenchmark.printFoosCJString:·gc.alloc.rate.norm               thrpt   20  464377.531 ±     2.872    B/op

[info] PrintingBenchmark.printIntsC                                          thrpt   20   18770.557 ±   360.538   ops/s
[info] PrintingBenchmark.printIntsC:·gc.alloc.rate.norm                      thrpt   20   74504.088 ±     0.173    B/op

[info] PrintingBenchmark.printIntsCJBytes                                    thrpt   20   35936.390 ±   962.170   ops/s
[info] PrintingBenchmark.printIntsCJBytes:·gc.alloc.rate.norm                thrpt   20   38496.047 ±     0.093    B/op

[info] PrintingBenchmark.printIntsCJString                                   thrpt   20   39662.014 ±   634.973   ops/s
[info] PrintingBenchmark.printIntsCJString:·gc.alloc.rate.norm               thrpt   20   42384.042 ±     0.082    B/op
```