### PR TITLE
Deprettify JSON

### DIFF
--- a/shared/src/main/scala/io/circe/jackson/package.scala
+++ b/shared/src/main/scala/io/circe/jackson/package.scala
@@ -1,6 +1,5 @@
 package io.circe
 
-import com.fasterxml.jackson.core.util.DefaultPrettyPrinter
 import java.io.{ BufferedWriter, ByteArrayOutputStream, OutputStreamWriter, StringWriter, Writer }
 import java.nio.ByteBuffer
 
@@ -18,10 +17,7 @@ import java.nio.ByteBuffer
 package object jackson extends WithJacksonMapper with JacksonParser with JacksonCompat {
 
   private[this] def writeJson(w: Writer, j: Json): Unit = {
-    val gen = jsonGenerator(w).setPrettyPrinter(
-      new DefaultPrettyPrinter()
-    )
-
+    val gen = jsonGenerator(w)
     makeWriter(mapper).writeValue(gen, j)
     w.flush()
   }


### PR DESCRIPTION
As [discussed on Finch's Gitter](https://gitter.im/finagle/finch?at=587932d7074f7be763ca0565), circe-jackson defaults to pretty printer (instead of compact), which could be costly in terms of both allocations and throughput. 

By disabling `DefaultPrettyPrinter` on the JSON generator, we can save some allocations and (perhaps) slightly improve the throughput.

UPDATE: The benchmark is pretty volatile (see the "Error" column) at least on my machine so I'm not sure I can totally trust it and measure/calculate the exact impact. Intuitively, not doing pretty printing is cheaper (fewer allocations for spaces, pretty printer), but I can't exactly confirm it with numbers.

```
BEFORE:

[info] Benchmark                                                              Mode  Cnt       Score       Error   Units
[info] PrintingBenchmark.printFoosCJBytes                                    thrpt   20    3155.092 ±   154.636   ops/s
[info] PrintingBenchmark.printFoosCJBytes:·gc.alloc.rate.norm                thrpt   20  259048.516 ±     1.003    B/op
[info] PrintingBenchmark.printFoosCJString                                   thrpt   20    3201.378 ±   141.171   ops/s
[info] PrintingBenchmark.printFoosCJString:·gc.alloc.rate.norm               thrpt   20  464376.524 ±     1.040    B/op
[info] PrintingBenchmark.printIntsCJBytes                                    thrpt   20   33623.950 ±  1157.741   ops/s
[info] PrintingBenchmark.printIntsCJBytes:·gc.alloc.rate.norm                thrpt   20   38496.050 ±     0.098    B/op
[info] PrintingBenchmark.printIntsCJString                                   thrpt   20   37986.979 ±   803.418   ops/s
[info] PrintingBenchmark.printIntsCJString:·gc.alloc.rate.norm               thrpt   20   42384.044 ±     0.087    B/op

AFTER:

[info] Benchmark                                                              Mode  Cnt       Score       Error   Units
[info] PrintingBenchmark.printFoosCJBytes                                    thrpt   20    3177.478 ±    96.584   ops/s
[info] PrintingBenchmark.printFoosCJBytes:·gc.alloc.rate.norm                thrpt   20  257804.523 ±  1079.784    B/op
[info] PrintingBenchmark.printFoosCJString                                   thrpt   20    3235.989 ±    86.101   ops/s
[info] PrintingBenchmark.printFoosCJString:·gc.alloc.rate.norm               thrpt   20  465153.379 ±   719.121    B/op
[info] PrintingBenchmark.printIntsCJBytes                                    thrpt   20   32755.331 ±  2278.756   ops/s
[info] PrintingBenchmark.printIntsCJBytes:·gc.alloc.rate.norm                thrpt   20   38484.050 ±    17.818    B/op
[info] PrintingBenchmark.printIntsCJString                                   thrpt   20   36895.228 ±  1799.816   ops/s
[info] PrintingBenchmark.printIntsCJString:·gc.alloc.rate.norm               thrpt   20   42352.045 ±     0.088    B/op
```