### PR TITLE
Make object mapper public

### DIFF
--- a/shared/src/main/scala/io/circe/jackson/WithJacksonMapper.scala
+++ b/shared/src/main/scala/io/circe/jackson/WithJacksonMapper.scala
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import java.io.{ File, Writer }
 
 class WithJacksonMapper {
-  protected final val mapper: ObjectMapper = (new ObjectMapper).registerModule(CirceJsonModule)
+  final val mapper: ObjectMapper = (new ObjectMapper).registerModule(CirceJsonModule)
   private[this] final val jsonFactory: JsonFactory = new JsonFactory(mapper)
 
   protected final def jsonStringParser(input: String): JsonParser = jsonFactory.createParser(input)


### PR DESCRIPTION
I apparently need access to the circe-specific mapper to interface with other libraries.